### PR TITLE
Revert "fix(container): update ghcr.io/home-operations/home-assistant docker tag ( 2025.6.2 → 2025.6.3 )"

### DIFF
--- a/kubernetes/darkstar/apps/home-automation/home-assistant/app/helm-release.yaml
+++ b/kubernetes/darkstar/apps/home-automation/home-assistant/app/helm-release.yaml
@@ -36,7 +36,7 @@ spec:
           app:
             image:
               repository: ghcr.io/home-operations/home-assistant
-              tag: 2025.6.3@sha256:6f6b427121f376c92dac2ce14b99ff088010da3f082142fd8b86b4ade563328f
+              tag: 2025.6.2@sha256:a77cf6de9d140fc2a66136336431217a65982f1ed3cf7dd9539046f3be49dc1b
             envFrom:
               - secretRef:
                   name: home-assistant-secret


### PR DESCRIPTION
Reverts drae/k8s-home-ops#3947
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Reverted the Home Assistant container image tag from 2025.6.3 back to 2025.6.2 in the Helm release configuration.

<!-- End of auto-generated description by cubic. -->

