### PR TITLE
Revert "feat(container): update ghcr.io/grafana/helm-charts/loki docker tag ( 6.34.0 → 6.35.0 ) - autoclosed"

### DIFF
--- a/kubernetes/darkstar/apps/observability/loki/app/helm-release.yaml
+++ b/kubernetes/darkstar/apps/observability/loki/app/helm-release.yaml
@@ -10,7 +10,7 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: 6.35.0
+    tag: 6.34.0
   url: oci://ghcr.io/grafana/helm-charts/loki
 ---
 apiVersion: helm.toolkit.fluxcd.io/v2


### PR DESCRIPTION
Reverts drae/k8s-home-ops#4104
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Reverted the Loki Helm chart version from 6.35.0 back to 6.34.0 to undo the previous update.

<!-- End of auto-generated description by cubic. -->

