### PR TITLE
Revert "chore(container): update ghcr.io/jacobalberty/unifi-docker:v9.5.21 docker digest ( b96378a → e21d932 )"

### DIFF
--- a/kubernetes/darkstar/apps/default/unifi/app/helm-release.yaml
+++ b/kubernetes/darkstar/apps/default/unifi/app/helm-release.yaml
@@ -18,7 +18,7 @@ spec:
           app:
             image:
               repository: ghcr.io/jacobalberty/unifi-docker
-              tag: v9.5.21@sha256:e21d932b36ceca1f3cfadb021f207016659bc8f7a59cd1b0d6ecf7ecd7067383
+              tag: v9.5.21@sha256:b96378a64887a6e23b44aa1306b0626517dc99e38770be16bdf94d9decc4ed28
             env:
               TZ: Europe/London
               RUNAS_UID0: "false"


### PR DESCRIPTION
Reverts drae/k8s-home-ops#4380