### PR TITLE
Revert "feat(container): update actions runner controller group ( 0.12.1 → 0.13.0 )"

### DIFF
--- a/kubernetes/darkstar/apps/actions-runner-system/actions-runner-controller/operator/helm-release.yaml
+++ b/kubernetes/darkstar/apps/actions-runner-system/actions-runner-controller/operator/helm-release.yaml
@@ -10,7 +10,7 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: 0.13.0
+    tag: 0.12.1
   url: oci://ghcr.io/actions/actions-runner-controller-charts/gha-runner-scale-set-controller
 ---
 apiVersion: helm.toolkit.fluxcd.io/v2

--- a/kubernetes/darkstar/apps/actions-runner-system/actions-runner-controller/runners/k8s-home-ops.yaml
+++ b/kubernetes/darkstar/apps/actions-runner-system/actions-runner-controller/runners/k8s-home-ops.yaml
@@ -10,7 +10,7 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: 0.13.0
+    tag: 0.12.1
   url: oci://ghcr.io/actions/actions-runner-controller-charts/gha-runner-scale-set
 ---
 # yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/helmrelease-helm-v2.json


### PR DESCRIPTION
Reverts drae/k8s-home-ops#4400
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Rolls back the Actions Runner Controller chart version from 0.13.0 to 0.12.1 for both the operator and the runner scale set. This restores the previous stable configuration.

<!-- End of auto-generated description by cubic. -->

