### PR TITLE
Revert "feat(container): update ghcr.io/coredns/charts/coredns docker tag ( 1.44.3 → 1.45.0 )"

### DIFF
--- a/kubernetes/darkstar/apps/kube-system/coredns/app/helm-release.yaml
+++ b/kubernetes/darkstar/apps/kube-system/coredns/app/helm-release.yaml
@@ -11,7 +11,7 @@ spec:
     operation: copy
   url: oci://ghcr.io/coredns/charts/coredns
   ref:
-    tag: 1.45.0
+    tag: 1.44.3
   verify:
     provider: cosign
 ---


### PR DESCRIPTION
Reverts drae/k8s-home-ops#4416

Problem with cosign verification
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Revert ghcr.io/coredns/charts/coredns Helm chart tag from 1.45.0 to 1.44.3 to restore cosign verification. This unblocks CoreDNS deployments in kube-system.

<!-- End of auto-generated description by cubic. -->

