### PR TITLE
Revert "feat(helm): update silence-operator ( 0.19.0 ➔ 0.20.0 )"

### DIFF
--- a/kubernetes/darkstar/apps/observability/silence-operator/app/helm-release.yaml
+++ b/kubernetes/darkstar/apps/observability/silence-operator/app/helm-release.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: silence-operator
-      version: 0.20.0
+      version: 0.19.0
       interval: 1h
       sourceRef:
         kind: HelmRepository


### PR DESCRIPTION
Reverts drae/k8s-home-ops#4500

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rolled back the silence-operator Helm chart from 0.20.0 to 0.19.0 to restore the previous stable behavior. This avoids issues seen with the 0.20.0 update.

<sup>Written for commit f24b7c24621799a8dbf1521ffc7f844d51b08bb5. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

