### PR TITLE
Revert "fix(container): update ghcr.io/stakater/charts/reloader ( 2.2.5 ➔ 2.2.6 )"

### DIFF
--- a/kubernetes/darkstar/apps/system/reloader/app/helm-release.yaml
+++ b/kubernetes/darkstar/apps/system/reloader/app/helm-release.yaml
@@ -10,7 +10,7 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: 2.2.6
+    tag: 2.2.5
   url: oci://ghcr.io/stakater/charts/reloader
 ---
 apiVersion: helm.toolkit.fluxcd.io/v2


### PR DESCRIPTION
Reverts drae/k8s-home-ops#4647