### PR TITLE
Revert "fix(container): update ghcr.io/siderolabs/installer ( v1.13.1 ➔ v1.13.2 )"

### DIFF
--- a/infrastructure/talos/darkstar/talconfig.yaml
+++ b/infrastructure/talos/darkstar/talconfig.yaml
@@ -4,7 +4,7 @@ clusterName: darkstar
 endpoint: https://darkstar.lan.starstreak.net:6443
 
 # renovate: datasource=docker depName=ghcr.io/siderolabs/installer
-talosVersion: v1.13.2
+talosVersion: v1.13.1
 # renovate: datasource=docker depName=ghcr.io/siderolabs/kubelet
 kubernetesVersion: v1.36.0
 

--- a/kubernetes/darkstar/apps/system-upgrade/tuppr/upgrades/talos.yaml
+++ b/kubernetes/darkstar/apps/system-upgrade/tuppr/upgrades/talos.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   talos:
     # renovate: datasource=docker depName=ghcr.io/siderolabs/installer
-    version: v1.13.2
+    version: v1.13.1
   policy:
     rebootMode: default
   healthChecks:


### PR DESCRIPTION
Reverts drae/k8s-home-ops#5311